### PR TITLE
chore: add org reusable CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build & Test
     uses: mca-nitw/.github/.github/workflows/node-ci.yml@main
     with:
-      node-version: "22.x"
+      node-version: '22.x'
 
   format:
     name: Format Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    uses: mca-nitw/.github/.github/workflows/node-ci.yml@main
+    with:
+      node-version: "22.x"
+
+  format:
+    name: Format Check
+    uses: mca-nitw/.github/.github/workflows/format-check.yml@main
+
+  security:
+    name: Security Scan
+    uses: mca-nitw/.github/.github/workflows/security-scan.yml@main
+    permissions:
+      contents: read
+      security-events: write

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+# Auto-generated files
+pnpm-lock.yaml
+package-lock.json
+yarn.lock
+
+# Renovate config
+renovate.json
+
+# Build artifacts
+**/dist/
+**/build/
+**/coverage/
+**/node_modules/
+
+# Logs
+*.log

--- a/client/src/api/OptimizedFetchData.ts
+++ b/client/src/api/OptimizedFetchData.ts
@@ -35,8 +35,7 @@ interface BatchResult {
   data?: BackendUserData
 }
 
-const getApiBaseUrl = (): string =>
-  import.meta.env.VITE_API_URL || ''
+const getApiBaseUrl = (): string => import.meta.env.VITE_API_URL || ''
 
 // Optimized single user data fetch using the new backend endpoint
 export const fetchOptimizedUserData = async (

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "allowImportingTsExtensions": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,40 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard"],
-  "timezone": "Asia/Kolkata",
-  "schedule": ["before 3am on monday"],
-  "prHourlyLimit": 2,
-  "prConcurrentLimit": 3,
-  "rangeStrategy": "replace",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "groupName": "non-major weekly",
-      "labels": ["dependencies", "auto-merge"]
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "groupName": "major updates",
-      "labels": ["dependencies", "major"],
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchDatasources": ["docker"],
-      "groupName": "docker",
-      "schedule": ["before 3am on monday"]
-    },
-    {
-      "matchCategories": ["lock-file-maintenance"],
-      "schedule": ["before 3am on monday"],
-      "automerge": true
-    }
-  ],
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": ["security"],
-    "schedule": ["at any time"]
-  }
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["github>mca-nitw/.github"]
 }


### PR DESCRIPTION
Follow-up to MCA-NITW/.github#9.

Adds CI to a previously CI-free repo via reusable workflows from the org. Three checks now run on every PR: build+test (auto-detects pnpm), Prettier format check, and security scan (Dependency Review + Trivy).

Also adds .prettierignore and reduces renovate.json to extend the shared preset.